### PR TITLE
DRAFT/PREVIEW --- [rtsan] Refactor where we get the stack

### DIFF
--- a/compiler-rt/lib/rtsan/CMakeLists.txt
+++ b/compiler-rt/lib/rtsan/CMakeLists.txt
@@ -5,7 +5,9 @@ set(RTSAN_CXX_SOURCES
   rtsan_context.cpp
   rtsan_diagnostics.cpp
   rtsan_flags.cpp
-  rtsan_interceptors.cpp)
+  rtsan_interceptors.cpp
+  rtsan_stats.cpp
+  )
 
 set(RTSAN_PREINIT_SOURCES
   rtsan_preinit.cpp)
@@ -16,7 +18,9 @@ set(RTSAN_HEADERS
   rtsan_context.h
   rtsan_diagnostics.h
   rtsan_flags.h
-  rtsan_flags.inc)
+  rtsan_flags.inc
+  rtsan_stats.h
+  )
 
 set(RTSAN_DEPS)
 

--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -22,16 +22,31 @@
 using namespace __rtsan;
 using namespace __sanitizer;
 
+namespace {
+enum class InitializationState : u8 {
+  Uninitialized,
+  Initializing,
+  Initialized,
+};
+} // namespace
+
 static StaticSpinMutex rtsan_inited_mutex;
 static atomic_uint8_t rtsan_initialized = {0};
 
-static void SetInitialized() {
-  atomic_store(&rtsan_initialized, 1, memory_order_release);
+static void SetInitializationState(InitializationState state) {
+  atomic_store(&rtsan_initialized, static_cast<u8>(state),
+               memory_order_release);
+}
+
+static InitializationState GetInitializationState() {
+  return static_cast<InitializationState>(
+      atomic_load(&rtsan_initialized, memory_order_acquire));
 }
 
 static auto DefaultErrorAction(DiagnosticsInfo info) {
   return [info]() {
-    __rtsan::PrintDiagnostics(info);
+    PrintDiagnostics(info);
+
     if (flags().halt_on_error)
       Die();
   };
@@ -40,13 +55,14 @@ static auto DefaultErrorAction(DiagnosticsInfo info) {
 extern "C" {
 
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
-  CHECK(!__rtsan_is_initialized());
+  CHECK(GetInitializationState() == InitializationState::Uninitialized);
+  SetInitializationState(InitializationState::Initializing);
 
   SanitizerToolName = "RealtimeSanitizer";
   InitializeFlags();
   InitializeInterceptors();
 
-  SetInitialized();
+  SetInitializationState(InitializationState::Initialized);
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_ensure_initialized() {
@@ -63,7 +79,7 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_ensure_initialized() {
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE bool __rtsan_is_initialized() {
-  return atomic_load(&rtsan_initialized, memory_order_acquire) == 1;
+  return GetInitializationState() == InitializationState::Initialized;
 }
 
 SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_realtime_enter() {
@@ -84,6 +100,10 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_enable() {
 
 SANITIZER_INTERFACE_ATTRIBUTE void
 __rtsan_notify_intercepted_call(const char *func_name) {
+  // While initializing, we need all intercepted functions to behave normally
+  if (GetInitializationState() == InitializationState::Initializing)
+    return;
+
   __rtsan_ensure_initialized();
   GET_CALLER_PC_BP;
   ExpectNotRealtime(GetContextForThisThread(),

--- a/compiler-rt/lib/rtsan/rtsan.cpp
+++ b/compiler-rt/lib/rtsan/rtsan.cpp
@@ -13,6 +13,7 @@
 #include <rtsan/rtsan_diagnostics.h>
 #include <rtsan/rtsan_flags.h>
 #include <rtsan/rtsan_interceptors.h>
+#include <rtsan/rtsan_stats.h>
 
 #include "sanitizer_common/sanitizer_atomic.h"
 #include "sanitizer_common/sanitizer_common.h"
@@ -43,8 +44,13 @@ static InitializationState GetInitializationState() {
       atomic_load(&rtsan_initialized, memory_order_acquire));
 }
 
+static void RtsanAtexit() { PrintStatisticsSummary(); }
+
 static auto DefaultErrorAction(DiagnosticsInfo info) {
   return [info]() {
+    if (flags().print_stats_on_exit)
+      IncrementTotalErrorCount();
+
     PrintDiagnostics(info);
 
     if (flags().halt_on_error)
@@ -61,6 +67,9 @@ SANITIZER_INTERFACE_ATTRIBUTE void __rtsan_init() {
   SanitizerToolName = "RealtimeSanitizer";
   InitializeFlags();
   InitializeInterceptors();
+
+  if (flags().print_stats_on_exit)
+    Atexit(RtsanAtexit);
 
   SetInitializationState(InitializationState::Initialized);
 }

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.cpp
@@ -39,13 +39,6 @@ public:
 };
 } // namespace
 
-static void PrintStackTrace(uptr pc, uptr bp) {
-  BufferedStackTrace stack{};
-
-  stack.Unwind(pc, bp, nullptr, common_flags()->fast_unwind_on_fatal);
-  stack.Print();
-}
-
 static void PrintError(const Decorator &decorator,
                        const DiagnosticsInfo &info) {
   const auto ErrorTypeStr = [&info]() -> const char * {
@@ -91,5 +84,4 @@ void __rtsan::PrintDiagnostics(const DiagnosticsInfo &info) {
   PrintError(d, info);
   PrintReason(d, info);
   Printf("%s", d.Default());
-  PrintStackTrace(info.pc, info.bp);
 }

--- a/compiler-rt/lib/rtsan/rtsan_diagnostics.h
+++ b/compiler-rt/lib/rtsan/rtsan_diagnostics.h
@@ -25,8 +25,6 @@ enum class DiagnosticsInfoType {
 struct DiagnosticsInfo {
   DiagnosticsInfoType type;
   const char *func_name;
-  __sanitizer::uptr pc;
-  __sanitizer::uptr bp;
 };
 
 void PrintDiagnostics(const DiagnosticsInfo &info);

--- a/compiler-rt/lib/rtsan/rtsan_flags.inc
+++ b/compiler-rt/lib/rtsan/rtsan_flags.inc
@@ -17,3 +17,4 @@
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
 RTSAN_FLAG(bool, halt_on_error, true, "Exit after first reported error.")
+RTSAN_FLAG(bool, print_stats_on_exit, false, "Print stats on exit.")

--- a/compiler-rt/lib/rtsan/rtsan_flags.inc
+++ b/compiler-rt/lib/rtsan/rtsan_flags.inc
@@ -16,5 +16,4 @@
 // RTSAN_FLAG(Type, Name, DefaultValue, Description)
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
-// Example flag, until we get a real one
-// RTSAN_FLAG(bool, halt_on_error, true, "If true, halt the program on error")
+RTSAN_FLAG(bool, halt_on_error, true, "Exit after first reported error.")

--- a/compiler-rt/lib/rtsan/rtsan_stats.cpp
+++ b/compiler-rt/lib/rtsan/rtsan_stats.cpp
@@ -1,0 +1,35 @@
+//===--- rtsan_stats.cpp - Realtime Sanitizer -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the RealtimeSanitizer runtime library
+//
+//===----------------------------------------------------------------------===//
+
+#include "rtsan/rtsan_stats.h"
+
+#include "sanitizer_common/sanitizer_atomic.h"
+#include "sanitizer_common/sanitizer_common.h"
+
+using namespace __sanitizer;
+using namespace __rtsan;
+
+static atomic_uint32_t rtsan_total_error_count{0};
+
+void __rtsan::IncrementTotalErrorCount() {
+  atomic_fetch_add(&rtsan_total_error_count, 1, memory_order_relaxed);
+}
+
+static u32 GetTotalErrorCount() {
+  return atomic_load(&rtsan_total_error_count, memory_order_relaxed);
+}
+
+void __rtsan::PrintStatisticsSummary() {
+  ScopedErrorReportLock l;
+  Printf("RealtimeSanitizer exit stats:\n");
+  Printf("    Total error count: %u\n", GetTotalErrorCount());
+}

--- a/compiler-rt/lib/rtsan/rtsan_stats.h
+++ b/compiler-rt/lib/rtsan/rtsan_stats.h
@@ -1,0 +1,21 @@
+//===--- rtsan_stats.h - Realtime Sanitizer ---------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Part of the RealtimeSanitizer runtime library
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+namespace __rtsan {
+
+void IncrementTotalErrorCount();
+
+void PrintStatisticsSummary();
+
+} // namespace __rtsan

--- a/compiler-rt/lib/rtsan/tests/rtsan_test_assertions.cpp
+++ b/compiler-rt/lib/rtsan/tests/rtsan_test_assertions.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 
 using namespace __rtsan;
+using namespace __sanitizer;
 
 class TestRtsanAssertions : public ::testing::Test {
 protected:
@@ -25,9 +26,10 @@ protected:
 
 static void ExpectViolationAction(__rtsan::Context &context,
                                   bool expect_violation_callback) {
-  ::testing::MockFunction<void()> mock_on_violation;
+  ::testing::MockFunction<void(const BufferedStackTrace &)> mock_on_violation;
   EXPECT_CALL(mock_on_violation, Call).Times(expect_violation_callback ? 1 : 0);
-  ExpectNotRealtime(context, mock_on_violation.AsStdFunction());
+  GET_CALLER_PC_BP;
+  ExpectNotRealtime(context, mock_on_violation.AsStdFunction(), pc, bp);
 }
 
 TEST_F(TestRtsanAssertions,

--- a/compiler-rt/test/rtsan/exit_stats.cpp
+++ b/compiler-rt/test/rtsan/exit_stats.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx -fsanitize=realtime %s -o %t
+// RUN: env RTSAN_OPTIONS="halt_on_error=false,print_stats_on_exit=true" %run %t 2>&1 | FileCheck %s
+
+// UNSUPPORTED: ios
+
+// Intent: Ensure exits stats are printed on exit.
+
+#include <unistd.h>
+
+void violation() [[clang::nonblocking]] {
+  const int kNumViolations = 10;
+  for (int i = 0; i < kNumViolations; i++) {
+    usleep(1);
+  }
+}
+
+int main() {
+  violation();
+  return 0;
+}
+
+// CHECK: RealtimeSanitizer exit stats:
+// CHECK-NEXT: Total error count: 10

--- a/compiler-rt/test/rtsan/halt_on_error.cpp
+++ b/compiler-rt/test/rtsan/halt_on_error.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsanitize=realtime %s -o %t
+// RUN: env RTSAN_OPTIONS="halt_on_error=false" %run %t 2>&1 | FileCheck %s
+// UNSUPPORTED: ios
+
+// Intent: Ensure that halt_on_error does not exit on the first violation.
+
+#include <stdlib.h>
+
+void *MallocViolation() { return malloc(10); }
+
+void FreeViolation(void *Ptr) { free(Ptr); }
+
+void process() [[clang::nonblocking]] {
+  void *Ptr = MallocViolation();
+  FreeViolation(Ptr);
+}
+
+int main() {
+  process();
+  return 0;
+  // CHECK: ==ERROR: RealtimeSanitizer
+  // CHECK-NEXT: {{.*`malloc`.*}}
+  // CHECK: ==ERROR: RealtimeSanitizer
+  // CHECK-NEXT: {{.*`free`.*}}
+}


### PR DESCRIPTION
NOTE: This is a preview PR showing the most complex refactor of the deduplication work. I want to make sure this is generally OK with you and still fits with our vision of the architecture.

# Why?

We now use the **unwound** stack for two operations.

1. (not visible in this PR) We use the unwound stack to deduplicate on the entire stack
2. We print the stack

Instead of unwinding twice, we need to be smart about where we calculate it.

# What's going on here?

## Removal of pc, bp, simplification of DiagnosticsInfo

Instead of keeping pc and bp with the `DiagnosticsInfo`, we pass it into ExpectNotRealtime.  This means we can greatly simplify the `DiagnosticsInfo` class

## Callback "OnErrorAction" now takes the stack directly

To ensure we re-use the same stack for deduplication and printing, we now pass it back to the "OnErrorAction" and it can decide what to do with it. In the DefaultErrorAction, we just print the stack, this leads to:

## Deleting  the PrintStackTrace function

If we already have an unwound stack, we have nothing to do in this function.